### PR TITLE
Fix README home page path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+You can start editing the page by modifying `src/app/(public)/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 


### PR DESCRIPTION
## Summary
- update README to point to `src/app/(public)/page.tsx`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6881c58298848328a09a7e892daddbee